### PR TITLE
Add/test autoscale on deletion

### DIFF
--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -462,6 +462,7 @@ worker_group_scale_locks = defaultdict(lambda: asyncio.Lock())
 
 
 @kopf.on.field("daskworkergroup.kubernetes.dask.org", field="spec.worker.replicas")
+@kopf.on.delete(labels={"dask.org/component": "worker"})
 async def daskworkergroup_replica_update(
     name, namespace, meta, spec, new, body, logger, **kwargs
 ):

--- a/dask_kubernetes/operator/controller/tests/test_controller.py
+++ b/dask_kubernetes/operator/controller/tests/test_controller.py
@@ -141,6 +141,14 @@ async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
                         "simple-default",
                     )
                     await client.wait_for_workers(3)
+                    k8s_cluster.kubectl(
+                        "delete",
+                        "pod",
+                        "-l",
+                        "dask.org/component=worker",
+                    )
+                    await client.wait_for_workers(0)  # initial deletion
+                    await client.wait_for_workers(3)  # recovery
 
 
 @pytest.mark.timeout(180)


### PR DESCRIPTION
## NOTE: This is a public repo, so nothing confidential in this PR please

Can't get these tests to run locally (Helm error), so trying on CI

The error:
```
Error: UPGRADE FAILED: "dask-gateway" has no deployed releases
```

```python
    @pytest.fixture(scope="session", autouse=True)
    def install_gateway(k8s_cluster):
        check_dependency("helm")
        # To ensure the operator can coexist with Gateway
>       subprocess.run(
            [
                "helm",
                "upgrade",
                "dask-gateway",
                "dask-gateway",
                "--install",
                "--repo=https://helm.dask.org",
                "--create-namespace",
                "--namespace",
                "dask-gateway",
            ],
            check=True,
            env={**os.environ},
        )
```